### PR TITLE
FIX: updated logic for student_comment field

### DIFF
--- a/src/API/api.py
+++ b/src/API/api.py
@@ -493,7 +493,7 @@ async def get_reviewers():
 
 
 class FeedbackRequest(BaseModel):
-    student_feedback: str
+    student_comment: str
     reviewer_id: Optional[UUID] = None
 
 
@@ -501,7 +501,7 @@ class FeedbackRequest(BaseModel):
 async def add_feedback_endpoint(certificate_id: UUID, payload: FeedbackRequest):
     """Store student comment and reviewer ID for a decision/certificate."""
     success = add_student_comment_and_reviewer(
-        certificate_id, payload.student_feedback, payload.reviewer_id
+        certificate_id, payload.student_comment, payload.reviewer_id
     )
     if not success:
         raise HTTPException(status_code=404, detail="Certificate not found")

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -32,14 +32,6 @@ class ReviewerDecision(str, enum.Enum):
     FAIL = "FAIL"  # Certificate rejected by reviewer
 
 
-class AppealStatus(str, enum.Enum):
-    """Enumeration for appeal statuses."""
-
-    PENDING = "PENDING"
-    APPROVED = "APPROVED"
-    REJECTED = "REJECTED"
-
-
 @dataclass
 class Student:
     """
@@ -259,7 +251,7 @@ class ApplicationSummary:
         ai_decision: AI decision result
         uploaded_at: When certificate was uploaded
         created_at: When decision was created
-        student_feedback: Student's feedback if any
+        student_comment: Student's comment if any
     """
 
     decision_id: UUID
@@ -273,7 +265,7 @@ class ApplicationSummary:
     uploaded_at: datetime
     created_at: datetime
     reviewer_decision: Optional[ReviewerDecision] = None
-    student_feedback: Optional[str] = None
+    student_comment: Optional[str] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -291,7 +283,7 @@ class ApplicationSummary:
             "reviewer_decision": self.reviewer_decision.value
             if self.reviewer_decision
             else None,
-            "student_feedback": self.student_feedback,
+            "student_comment": self.student_comment,
         }
 
 


### PR DESCRIPTION
- student_comment is now optional for all certificates (not just AI-rejected ones)
- AI-positive decisions don't require student_comment - they can have it as NULL
- AI-rejected decisions can have student_comment added by students when requesting review
- Human-reviewed decisions keep their existing student_comment value
-  Creates the correct decisions table with student_comment field

- Removes all the old appeal-related columns
- No longer has the AppealStatus enum
- Sets up the proper indexes
